### PR TITLE
Windows building & line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.settings/SDCC Batch.launch
+++ b/.settings/SDCC Batch.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.ui.externaltools.ProgramLaunchConfigurationType">
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LAUNCH_CONFIGURATION_BUILD_SCOPE" value="${none}"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/BMSBattery_S_controllers_firmware/Start_Compiling.bat}"/>
-<stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/BMSBattery_S_controllers_firmware}"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LAUNCH_CONFIGURATION_BUILD_SCOPE" value="${none}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc:/BMSBattery_S_controllers_firmware/scripts/Start_Compiling.bat}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc:/BMSBattery_S_controllers_firmware}"/>
 </launchConfiguration>

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -18,11 +18,16 @@ PLATFORM = stm8
 PNAME = main
 
 #Directory for helpers
-IDIR = StdPeriphLib/inc
-SDIR = StdPeriphLib/src
+IDIR = lib/inc
+SDIR = lib/src
+
+#.c files in src
+SRC = src
+#.h files in include/
+INC = include
 
 # In case you ever want a different name for the main source file
-MAINSRC = $(PNAME).c
+MAINSRC = $(SRC)/$(PNAME).c
 
 ELF_SECTIONS_TO_REMOVE = -R DATA -R INITIALIZED -R SSEG -R .debug_line -R .debug_loc -R .debug_abbrev -R .debug_info -R .debug_pubnames -R .debug_frame
 
@@ -38,42 +43,62 @@ EXTRASRCS = \
 	$(SDIR)/stm8s_tim2.c \
 	$(SDIR)/stm8s_adc1.c \
 	$(SDIR)/stm8s_flash.c \
-	BOdisplay.c \
-	ACAcontrollerState.c \
-	ACAeeprom.c \
-	ACAsetPoint.c \
-	ACAcommons.c \
-	gpio.c \
-	cruise_control.c \
-	uart.c \
-	adc.c \
-	brake.c \
-	timers.c \
-	pwm.c \
-	motor.c \
-	PAS.c \
-	SPEED.c \
-	display.c \
-	display_kingmeter.c
+	$(SRC)/BOdisplay.c \
+	$(SRC)/ACAcontrollerState.c \
+	$(SRC)/ACAeeprom.c \
+	$(SRC)/ACAsetPoint.c \
+	$(SRC)/ACAcommons.c \
+	$(SRC)/gpio.c \
+	$(SRC)/cruise_control.c \
+	$(SRC)/uart.c \
+	$(SRC)/adc.c \
+	$(SRC)/brake.c \
+	$(SRC)/timers.c \
+	$(SRC)/pwm.c \
+	$(SRC)/motor.c \
+	$(SRC)/PAS.c \
+	$(SRC)/SPEED.c \
+	$(SRC)/display.c \
+	$(SRC)/display_lcd8.c \
+	$(SRC)/display_kingmeter.c
 
-HEADERS = BOdisplay.h ACAcommons.h ACAsetPoint.h ACAcontrollerState.h ACAeeprom.h adc.h  brake.h  cruise_control.h  gpio.h  interrupts.h  main.h  motor.h  pwm.h  timers.h  uart.h  PAS.h  SPEED.h  
+HEADERS = \
+	$(INC)/BOdisplay.h \
+	$(INC)/ACAcommons.h \
+	$(INC)/ACAsetPoint.h \
+	$(INC)/ACAcontrollerState.h \
+	$(INC)/ACAeeprom.h \
+	$(INC)/adc.h \
+	$(INC)/brake.h \
+	$(INC)/cruise_control.h \
+	$(INC)/gpio.h \
+	$(INC)/interrupts.h \
+	$(INC)/main.h \
+	$(INC)/motor.h \
+	$(INC)/pwm.h \
+	$(INC)/timers.h \
+	$(INC)/uart.h \
+	$(INC)/PAS.h \
+	$(INC)/SPEED.h \
 
 # The list of .rel files can be derived from the list of their source files
 RELS = $(EXTRASRCS:.c=.rel)
 
-INCLUDES = -I$(IDIR) -I. 
-CFLAGS   = -m$(PLATFORM) --std-c99 --nolospre
-ELF_FLAGS = --out-fmt-ihx --debug
-LIBS     = 
+INCLUDES = -I$(IDIR) -I$(INC) 
+CFLAGS   = -m$(PLATFORM) --std-c99
+#--nolospre
+ELF_FLAGS = --out-fmt-ihx
+#--debug
+LIBS     =
+ 
 # This just provides the conventional target name "all"; it is optional
 # Note: I assume you set PNAME via some means not exhibited in your original file
 all: $(PNAME)
 
 # How to build the overall program
-
 $(PNAME): $(MAINSRC) $(RELS)
 	$(CC) $(INCLUDES) $(CFLAGS) $(ELF_FLAGS) $(LIBS) $(MAINSRC) $(RELS)
-# $(SIZE) $(PNAME).elf
+#	$(SIZE) $(PNAME).elf
 # $(OBJCOPY) -O binary $(ELF_SECTIONS_TO_REMOVE) 
 # $(PNAME).elf $(PNAME).bin
 
@@ -87,8 +112,8 @@ $(PNAME): $(MAINSRC) $(RELS)
 .SUFFIXES: .c .rel
 
 # hex:
-#	$(OBJCOPY) -O ihex $(ELF_SECTIONS_TO_REMOVE) $(PNAME).elf 
-# $(PNAME).ihx
+#$(OBJCOPY) -O ihex $(ELF_SECTIONS_TO_REMOVE) $(PNAME).elf 
+#$(PNAME).ihx
 
 # flash:
 #	stm8flash -cstlinkv2 -pstm8s105?6 -w$(PNAME).ihx

--- a/Makefile_windows
+++ b/Makefile_windows
@@ -1,7 +1,4 @@
-#Makefile for STM8 Examples with SDCC compiler
-#Author:	Saeid Yazdani
-#Website:	WWW.EMBEDONIX.COM
-#Copyright 2016
+#Original Makefile template from Saeid Yazdani (c) 2016
 #LICENSE:	GNU-LGPL
 
 .PHONY: all clean
@@ -9,7 +6,6 @@
 #Compiler
 CC = sdcc
 OBJCOPY = stm8-objcopy
-SIZE = stm8-size
 
 #Platform
 PLATFORM = stm8
@@ -98,9 +94,6 @@ all: $(PNAME)
 # How to build the overall program
 $(PNAME): $(MAINSRC) $(RELS)
 	$(CC) $(INCLUDES) $(CFLAGS) $(ELF_FLAGS) $(LIBS) $(MAINSRC) $(RELS)
-#	$(SIZE) $(PNAME).elf
-# $(OBJCOPY) -O binary $(ELF_SECTIONS_TO_REMOVE) 
-# $(PNAME).elf $(PNAME).bin
 
 # How to build any .rel file from its corresponding .c file
 # GNU would have you use a pattern rule for this, but that's GNU-specific
@@ -115,10 +108,10 @@ $(PNAME): $(MAINSRC) $(RELS)
 #$(OBJCOPY) -O ihex $(ELF_SECTIONS_TO_REMOVE) $(PNAME).elf 
 #$(PNAME).ihx
 
-# flash:
-#	stm8flash -cstlinkv2 -pstm8s105?6 -w$(PNAME).ihx
+flash:
+	stm8flash -cstlinkv2 -pstm8s105?6 -w$(PNAME).ihx
 
-ENTF = cmd /C del
+ENTF = cmd /C del /S
 
 clean:
 	echo "Cleaning files..."
@@ -130,6 +123,6 @@ clean:
 	$(ENTF) *.sym
 	$(ENTF) *.cdb
 	$(ENTF) *.map
-	$(ENTF) *.adb 
+	$(ENTF) *.adb
 	echo "Done."
 

--- a/scripts/Start_Compiling.bat
+++ b/scripts/Start_Compiling.bat
@@ -1,12 +1,15 @@
 PATH = %PATH%;C:\Program Files\STMicroelectronics\st_toolset\stvp;C:\Program Files (x86)\STMicroelectronics\st_toolset\stvp;C:\SDCC\usr\local\bin
 REM ;%~dp0tools\cygwin\bin
 cd %~dp0
-del main.hex
 sdcc --version
-make -f Makefile_windows clean
-make -f Makefile_windows
+::Move location to project folder
+cd ..
+del main.hex
+del main.ihx
+tooling\make -f Makefile_windows clean
+tooling\make -f Makefile_windows
 ren main.ihx main.hex
-make -f Makefile_windows clean
+tooling\make -f Makefile_windows clean
 
 STVP_CmdLine -BoardName=ST-LINK -ProgMode=SWIM -Port=USB -Device=STM8S105x6 -FileProg=main.hex -verbose -no_loop
 


### PR DESCRIPTION
Fixed building in windows:
Building with new file locations like /scripts/ folder & changed make tooling
Changed makefile-windows to be up to date with the linux variant. I dont see unification of makefile to be necessary at this time.

normalized LF line-endings, unifying all line endings to be the same for cross platform editing

